### PR TITLE
18.0 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 12321
-RBY_VER=2.7.8
+RBY_VER=3.1
 
 include $(FAB_PATH)/common/mk/turnkey/rails.mk
 include $(FAB_PATH)/common/mk/turnkey.mk

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 12321
+RBY_VER=2.7.8
 
 include $(FAB_PATH)/common/mk/turnkey/rails.mk
 include $(FAB_PATH)/common/mk/turnkey.mk

--- a/changelog
+++ b/changelog
@@ -1,11 +1,90 @@
-turnkey-foodsoft-18.0 (1) turnkey; urgency=low
+tturnkey-foodsoft-18.0 (1) turnkey; urgency=low
 
-  * Update Foodsoft to install latest version: 4.8.0
+  * Update Foodsoft to install latest version: v4.8.1
+    [Zhenya Hvorostian <zhenya@turnkeylinux.org>]
 
-  * Note: Please refer to turnkey-core's 18.0 changelog for changes common to all
-    appliances. Here we only describe changes specific to this appliance.
+  * Updated Ruby version to 3.1.x
 
- -- Zhenya Hvorostian <zhenya@turnkeylinux.org>  Fri, 10 Oct 2023 16:58:00 +0300
+  * Confconsole: bugfix broken DNS-01 Let's Encrypt challenge- closes #1876 &
+    #1895.
+    [Jeremy Davis <jeremy@turnkeylinux.org>]
+
+  * Ensure hashfile includes URL to public key - closes #1864.
+
+  * Include webmin-logviewer module by default - closes #1866.
+
+  * Upgraded base distribution to Debian 12.x/Bookworm.
+
+  * Configuration console (confconsole):
+    - Support for DNS-01 Let's Encrypt challenges.
+      [ Oleh Dmytrychenko <dmytrychenko.oleh@gmail.com> github: @NitrogenUA ]
+    - Support for getting Let's Encrypt cert via IPv6 - closes #1785.
+    - Refactor network interface code to ensure that it works as expected and
+      supports more possible network config (e.g. hotplug interfaces & wifi).
+    - Show error message rather than stacktrace when window resized to
+      incompatable resolution - closes  #1609.
+      [ Stefan Davis <stefan@turnkeylinux.org> ]
+    - Bugfix exception when quitting configuration of mail relay.
+      [ Oleh Dmytrychenko <dmytrychenko.oleh@gmail.com> github: @NitrogenUA ]
+    - Improve code quality: implement typing, fstrings and make (mostly) PEP8
+      compliant.
+      [Stefan Davis <stefan@turnkeylinux.org> & Jeremy Davis
+
+  * Firstboot Initialization (inithooks):
+    - Refactor start up (now hooks into getty process, rather than having it's
+      own service).
+      [ Stefan Davis <stefan@turnkeylinux.org> ]
+    - Refactor firstboot.d/01ipconfig (and 09hostname) to ensure that hostname
+      is included in dhcp info when set via inithooks.
+    - Package turnkey-make-ssl-cert script (from common overlay - now packaged
+      as turnkey-ssl). Refactor relevant scripts to leverage turnkey-ssl.
+    - Refactor run script - use bashisms and general tidying.
+    - Show blacklisted password characters more nicely.
+    - Misc packaging changes/improvements.
+    - Support returning output from MySQL - i.e. support 'SELECT'. (Only
+      applies to apps that include MySQL/MariaDB).
+
+  * Web management console (webmin):
+    - Upgraded webmin to v2.105.
+    - Replace webmin-shell with webmin-xterm module by default - closes #1904.
+    - Removed stunnel reverse proxy (Webmin hosted directly now).
+    - Ensure that Webmin uses HTTPS with default cert
+      (/etc/ssl/private/cert.pem).
+    - Disabled Webmin Let's Encrypt (for now).
+
+  * Web shell (shellinabox):
+    - Completely removed in v18.0 (Webmin now has a proper interactive shell).
+    - Note: previous v18.0 releases did not include webmin-xterm pkg - see
+      above webmin note &/or #1904.
+
+  * Backup (tklbam):
+    - Ported dependencies to Debian Bookworm; otherwise unchanged.
+
+  * Security hardening & improvements:
+    - Generate and use new TurnKey Bookworm keys.
+    - Automate (and require) default pinning for packages from Debian
+      backports. Also support non-free backports.
+
+  * IPv6 support:
+    - Adminer (only on LAMP based apps) listen on IPv6.
+    - Nginx/NodeJS (NodeJS based apps only) listen on IPv6.
+
+  * Misc bugfixes & feature implementations:
+    - Remove rsyslog package (systemd journal now all that's needed).
+    - Include zstd compression support.
+    - Enable new non-free-firmware apt repo by default.
+    - Improve turnkey-artisan so that it works reliably in cron jobs (only
+      Laravel based LAMP apps).
+
+  * Set mod_evasive log location - makes debugging easier.
+    [ Jeremy Davis <jeremy@turnkeylinux.org> ]
+
+  * Include and enable mod_evasive and mod_security2 by default in Apache.
+    [ Stefan Davis <Stefan@turnkeylinux.org> ]
+
+  * Use MariaDB (MySQL replacement) v10.11.3 (from debian repos).
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Fri, 14 Jun 2024 05:13:10 +0000
 
 turnkey-foodsoft-16.1 (1) turnkey; urgency=low
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,12 @@
+turnkey-foodsoft-18.0 (1) turnkey; urgency=low
+
+  * Update Foodsoft to install latest version: 4.8.0
+
+  * Note: Please refer to turnkey-core's 18.0 changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Zhenya Hvorostian <zhenya@turnkeylinux.org>  Fri, 10 Oct 2023 16:58:00 +0300
+
 turnkey-foodsoft-16.1 (1) turnkey; urgency=low
 
   * Update Foodsoft to install latest version: 4.7.1

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -13,5 +13,4 @@ dlfs() {
 }
 
 # download standart foodsoft
-dlfs foodcoops/foodsoft       v4.8.0        standard
-
+dlfs foodcoops/foodsoft       v4.8.1        standard

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -13,5 +13,5 @@ dlfs() {
 }
 
 # download standart foodsoft
-dlfs foodcoops/foodsoft       v4.7.1        standard
+dlfs foodcoops/foodsoft       v4.8.0        standard
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -40,8 +40,9 @@ export SECRET_KEY_BASE=$SECRET_KEY
 
 # install dependencies
 [ "$FAB_HTTP_PROXY" ] && export HTTP_PROXY=$FAB_HTTP_PROXY
-gem install bundler:1.15.4
-bundle install --without test development
+gem install bundler
+# bundle config build.libv8 --with-system-v8 
+bundle install --without test development --deployment
 bundle exec rake foodsoft:setup:stock_config RAILS_ENV=production
 
 unset HTTP_PROXY

--- a/conf.d/main
+++ b/conf.d/main
@@ -41,7 +41,7 @@ export SECRET_KEY_BASE=$SECRET_KEY
 # install dependencies
 [ "$FAB_HTTP_PROXY" ] && export HTTP_PROXY=$FAB_HTTP_PROXY
 gem install bundler
-# bundle config build.libv8 --with-system-v8 
+
 bundle install --without test development --deployment
 bundle exec rake foodsoft:setup:stock_config RAILS_ENV=production
 

--- a/overlay/usr/lib/inithooks/bin/foodsoft.py
+++ b/overlay/usr/lib/inithooks/bin/foodsoft.py
@@ -10,13 +10,13 @@ import os
 import sys
 import glob
 import getopt
-import inithooks_cache
+from libinithooks import inithooks_cache
 import string
 import subprocess
 
 from subprocess import Popen, PIPE
 
-from dialog_wrapper import Dialog
+from libinithooks.dialog_wrapper import Dialog
 
 APPS_PATH='/var/www/'
 APP_DEFAULT_PATH=os.path.join(APPS_PATH, 'foodsoft')

--- a/plan/main
+++ b/plan/main
@@ -11,4 +11,3 @@ libmagick++-dev
 libmagickwand-dev
 
 libsqlite3-dev
-libqtwebkit-dev


### PR DESCRIPTION
Includes Zenya's work from https://github.com/turnkeylinux-apps/foodsoft/pull/11 - rebased on `master` to resolve merge conflict

Plus:
- bumped Foodsoft version
- bumped Ruby version
- updated changelog with common changes (and updated date)